### PR TITLE
[PRC] - Tidied up MANIFEST as suggested by CPANTS.

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -10,27 +10,9 @@ lib/Term/Clui/FileSelect.pm
 LICENSE
 maint/releaseprep
 Makefile.PL
-MANIFEST			This list of files
+MANIFEST                       This list of files
+MANIFEST.SKIP
 py/TermClui.py
 py/test_script
 README
 t/term_clui.t
-Term-Clui-1.73/.travis.yml
-Term-Clui-1.73/Changes
-Term-Clui-1.73/examples/audio_stuff
-Term-Clui-1.73/examples/choose
-Term-Clui-1.73/examples/linux_admin
-Term-Clui-1.73/examples/login_shell
-Term-Clui-1.73/examples/test_script
-Term-Clui-1.73/lib/Term/Clui.pm
-Term-Clui-1.73/lib/Term/Clui/FileSelect.pm
-Term-Clui-1.73/LICENSE
-Term-Clui-1.73/maint/releaseprep
-Term-Clui-1.73/Makefile.PL
-Term-Clui-1.73/MANIFEST
-Term-Clui-1.73/META.json
-Term-Clui-1.73/META.yml
-Term-Clui-1.73/py/TermClui.py
-Term-Clui-1.73/py/test_script
-Term-Clui-1.73/README
-Term-Clui-1.73/t/term_clui.t

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -1,0 +1,14 @@
+^MYMETA.json$
+^MYMETA.yml$
+^_eumm
+^Makefile$
+^blib/
+^pm_to_blib
+^blibdirs
+^Build$
+^Build.bat$
+^perl.core$
+^pod2htm
+^.gitignore
+^_build/
+^.git/


### PR DESCRIPTION
Hi @plicease 

As a part of PRC, I propose the above PR. Please review it. It tries to address the following issue suggested by CPANTS.

https://cpants.cpanauthors.org/release/PLICEASE/Term-Clui-1.73

          MANIFEST (38) does not match dist (19):
          Missing in Dist: Term-Clui-1.73/.travis.yml, Term-Clui-1.73/Changes, Term-Clui-1.73/LICENSE, Term-Clui-1.73/MANIFEST, Term-Clui-1.73/META.json, Term-Clui-1.73/META.yml, Term-Clui-1.73/Makefile.PL, Term-Clui-1.73/README, Term-Clui-1.73/examples/audio_stuff, Term-Clui-1.73/examples/choose, Term-Clui-1.73/examples/linux_admin, Term-Clui-1.73/examples/login_shell, Term-Clui-1.73/examples/test_script, Term-Clui-1.73/lib/Term/Clui.pm, Term-Clui-1.73/lib/Term/Clui/FileSelect.pm, Term-Clui-1.73/maint/releaseprep, Term-Clui-1.73/py/TermClui.py, Term-Clui-1.73/py/test_script, Term-Clui-1.73/t/term_clui.t

Many Thanks.
Best Regards,
Mohammad S Anwar